### PR TITLE
Qemu dts mod

### DIFF
--- a/qemu_usage/qemu_dts_mod.txt
+++ b/qemu_usage/qemu_dts_mod.txt
@@ -1,0 +1,29 @@
+    reserved-memory {
+            #address-cells = <2>;
+            #size-cells = <2>;
+            ranges;
+            service_reserved1: svcbuffer@1 {
+                compatible = "shared-dma-pool";
+                no-map;
+                reg = <0x0 0x80000000 0x0 0x40000000>;
+                alignment = <0x1000>;
+            };
+            service_reserved2: svcbuffer@2 {
+                compatible = "shared-dma-pool";
+                no-map;
+                reg = <0x0 0xc0000000 0x0 0x80000000>;
+                alignment = <0x1000>;
+            };
+    };
+    udmabuf@0 {
+        compatible = "ikwzm,u-dma-buf";
+        device-name = "udmabuf0";
+        size = <0x40000000>; // 1GiB
+        memory-region = <&service_reserved1>;
+    };
+    udmabuf@1 {
+        compatible = "ikwzm,u-dma-buf";
+        device-name = "udmabuf1";
+        size = <0x80000000>; // 2GiB
+        memory-region = <&service_reserved2>;
+    };

--- a/qemu_usage/qemu_dts_mod.txt
+++ b/qemu_usage/qemu_dts_mod.txt
@@ -1,29 +1,29 @@
-    reserved-memory {
-            #address-cells = <2>;
-            #size-cells = <2>;
-            ranges;
-            service_reserved1: svcbuffer@1 {
-                compatible = "shared-dma-pool";
-                no-map;
-                reg = <0x0 0x80000000 0x0 0x40000000>;
-                alignment = <0x1000>;
-            };
-            service_reserved2: svcbuffer@2 {
-                compatible = "shared-dma-pool";
-                no-map;
-                reg = <0x0 0xc0000000 0x0 0x80000000>;
-                alignment = <0x1000>;
-            };
-    };
-    udmabuf@0 {
-        compatible = "ikwzm,u-dma-buf";
-        device-name = "udmabuf0";
-        size = <0x40000000>; // 1GiB
-        memory-region = <&service_reserved1>;
-    };
-    udmabuf@1 {
-        compatible = "ikwzm,u-dma-buf";
-        device-name = "udmabuf1";
-        size = <0x80000000>; // 2GiB
-        memory-region = <&service_reserved2>;
-    };
+        reserved-memory {
+                #address-cells = <2>;
+                #size-cells = <2>;
+                ranges;
+                service_reserved1: svcbuffer@1 {
+                    compatible = "shared-dma-pool";
+                    no-map;
+                    reg = <0x0 0x80000000 0x0 0x40000000>;
+                    alignment = <0x1000>;
+                };
+                service_reserved2: svcbuffer@2 {
+                    compatible = "shared-dma-pool";
+                    no-map;
+                    reg = <0x0 0xc0000000 0x0 0x80000000>;
+                    alignment = <0x1000>;
+                };
+        };
+        udmabuf@0 {
+            compatible = "ikwzm,u-dma-buf";
+            device-name = "udmabuf0";
+            size = <0x40000000>; // 1GiB
+            memory-region = <&service_reserved1>;
+        };
+        udmabuf@1 {
+            compatible = "ikwzm,u-dma-buf";
+            device-name = "udmabuf1";
+            size = <0x80000000>; // 2GiB
+            memory-region = <&service_reserved2>;
+        };


### PR DESCRIPTION
Adding the 'dts' file modifications needed for creating the 2 udma buffers (udmabuf0 , udmabuf1) that user mode CMA interfaces depend on. Just adding the 'mod'/delta. These could be added to the auto-generated 'dts' files and compiled to 'dtb'.  

Primarily meant for usage in Qemu setups. 

Accompanying PR: https://github.com/tsisw/tsi_yocto_workspace/pull/133